### PR TITLE
Copy all bmp files automatically

### DIFF
--- a/MikeCp.Umbraco.HackathonIssuePrinter.PrinterService/MikeCp.Umbraco.HackathonIssuePrinter.PrinterService.csproj
+++ b/MikeCp.Umbraco.HackathonIssuePrinter.PrinterService/MikeCp.Umbraco.HackathonIssuePrinter.PrinterService.csproj
@@ -7,13 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="Assets\footer.bmp">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="Assets\our_heart.bmp">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="Assets\umbraco.bmp">
+    <None Update="Assets\*.bmp">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="POS58D\PortIO.dll">


### PR DESCRIPTION
When I added a new bmp file to be printed on the ticket, it would just not work. Turns out the files are hardcoded here one by one. Replacing with a wildcard makes sure that all required `.bmp` assets get copied over.